### PR TITLE
refactor: frontend login process 개선

### DIFF
--- a/src/backend/auth/httpMethods/POST.ts
+++ b/src/backend/auth/httpMethods/POST.ts
@@ -9,8 +9,6 @@ import {
 import { AxiosError } from 'axios';
 import { NextApiRequest, NextApiResponse } from 'next';
 
-let hasGetTokenRequest = false;
-
 export async function POST(
   req: NextApiRequest,
   res: NextApiResponse<GoogleUrl | Login | Response | AxiosError>
@@ -19,13 +17,6 @@ export async function POST(
 
   switch (body.type) {
     case 'GET_TOKEN': {
-      if (hasGetTokenRequest) {
-        res.status(429).end();
-        hasGetTokenRequest = false;
-        return;
-      }
-      hasGetTokenRequest = true;
-
       const { tokens } = await oauth2Client.getToken(body.code);
 
       oauth2Client.setCredentials(tokens);

--- a/src/features/auth/apis/mutations/useGetAccessToken.ts
+++ b/src/features/auth/apis/mutations/useGetAccessToken.ts
@@ -1,9 +1,0 @@
-import { useMutation } from '@tanstack/react-query';
-import { getAccessToken } from '@/features/auth/apis/index.ts';
-
-const useGetAccessToken = () =>
-  useMutation({
-    mutationFn: (code: string) => getAccessToken(code),
-  });
-
-export default useGetAccessToken;

--- a/src/features/auth/apis/mutations/useGetAccessTokenByRefreshToken.ts
+++ b/src/features/auth/apis/mutations/useGetAccessTokenByRefreshToken.ts
@@ -1,7 +1,0 @@
-import { useMutation } from '@tanstack/react-query';
-import { getAccessTokenByRefreshToken } from '@/features/auth/apis/index.ts';
-
-const useGetAccessTokenByRefreshToken = () =>
-  useMutation({ mutationFn: () => getAccessTokenByRefreshToken() });
-
-export default useGetAccessTokenByRefreshToken;

--- a/src/features/auth/apis/mutations/useGetUserInfo.ts
+++ b/src/features/auth/apis/mutations/useGetUserInfo.ts
@@ -1,9 +1,0 @@
-import { useMutation } from '@tanstack/react-query';
-import { getUserInfo } from '@/features/auth/apis/index.ts';
-
-const useGetUserInfo = () =>
-  useMutation({
-    mutationFn: (accessToken: string) => getUserInfo(accessToken),
-  });
-
-export default useGetUserInfo;

--- a/src/features/auth/apis/mutations/useLogoutMutation.ts
+++ b/src/features/auth/apis/mutations/useLogoutMutation.ts
@@ -1,5 +1,6 @@
 import { useMutation } from '@tanstack/react-query';
 import { logout } from '@/features/auth/apis/index.ts';
 
-const useLogout = () => useMutation({ mutationFn: logout });
-export default useLogout;
+export default function useLogoutMutation() {
+  return useMutation({ mutationFn: logout });
+}

--- a/src/features/auth/apis/queries/useGetAccessToken.ts
+++ b/src/features/auth/apis/queries/useGetAccessToken.ts
@@ -1,0 +1,14 @@
+import { getAccessToken } from '@/features/auth/apis/index.ts';
+import { AuthToken } from '@/features/auth/apis/interfaces.ts';
+import { AUTH_KEY } from '@/constants/queryKey.ts';
+import { useQuery } from '@tanstack/react-query';
+
+const useGetAccessToken = (code: string) =>
+  useQuery<AuthToken>({
+    queryKey: [AUTH_KEY, code],
+    queryFn: () => getAccessToken(code),
+    enabled: !!code,
+    staleTime: Infinity,
+  });
+
+export default useGetAccessToken;

--- a/src/features/auth/apis/queries/useGetUserInfo.ts
+++ b/src/features/auth/apis/queries/useGetUserInfo.ts
@@ -1,0 +1,14 @@
+import { AUTH_KEY } from '@/constants/queryKey.ts';
+import { getUserInfo } from '@/features/auth/apis/index.ts';
+import { UserInfo } from '@/features/auth/apis/interfaces.ts';
+import { useQuery } from '@tanstack/react-query';
+
+const useGetUserInfo = (accessToken: string) =>
+  useQuery<UserInfo>({
+    queryKey: [AUTH_KEY, accessToken],
+    queryFn: () => getUserInfo(accessToken),
+    enabled: !!accessToken,
+    staleTime: Infinity,
+  });
+
+export default useGetUserInfo;

--- a/src/features/auth/components/LoginSection/LoginSection.tsx
+++ b/src/features/auth/components/LoginSection/LoginSection.tsx
@@ -3,15 +3,11 @@ import jiaryLogo from '@/static/jiary-logo.svg';
 import googleLogo from '@/static/auth/google_signin.png';
 import * as style from './LoginSection.css.ts';
 import useGetAuthCode from '@/features/auth/apis/queries/useGetAuthCode.ts';
-import { OpenLoginPopup } from '@/features/auth/hooks/useAuth.ts';
+import { useLoginPopup } from '@/features/auth/hooks/useLoginPopup.ts';
 
-export default function LoginSection({
-  openLoginPopup,
-}: {
-  openLoginPopup: OpenLoginPopup;
-}) {
+export default function LoginSection() {
   const { data } = useGetAuthCode();
-  const handleLoginClick = () => openLoginPopup(data?.location);
+  const { openLoginPopup } = useLoginPopup();
 
   return (
     <div className={style.container}>
@@ -46,7 +42,10 @@ export default function LoginSection({
       </p>
 
       <div className={style.buttonWrapper}>
-        <button onClick={handleLoginClick} className={style.loginButton}>
+        <button
+          onClick={() => openLoginPopup(data?.location)}
+          className={style.loginButton}
+        >
           <Image
             src={googleLogo}
             alt="Google Logo"

--- a/src/features/auth/hooks/useAuth.ts
+++ b/src/features/auth/hooks/useAuth.ts
@@ -1,96 +1,52 @@
 import { useDispatch } from 'react-redux';
-import {
-  removeAccessToken,
-  removeUser,
-  setAccessToken,
-  setUser,
-} from '@/store/slices/authSlice.ts';
+import { setAccessToken, setUser } from '@/store/slices/authSlice.ts';
 import { MESSAGE_TYPE } from '@/constants/auth.ts';
-import useGetAccessToken from '@/features/auth/apis/mutations/useGetAccessToken.ts';
-import useLogout from '@/features/auth/apis/mutations/useLogout.ts';
-import useGetUserInfo from '@/features/auth/apis/mutations/useGetUserInfo.ts';
+import useGetAccessToken from '@/features/auth/apis/queries/useGetAccessToken.ts';
+import useGetUserInfo from '@/features/auth/apis/queries/useGetUserInfo.ts';
 import { useRouter } from 'next/router';
 import { JIARY_DOMAIN } from '@/constants/domain.ts';
-import { useQueryClient } from '@tanstack/react-query';
-
-let popupWindow: Window | null = null;
-
-export type OpenLoginPopup = {
-  (url: string | undefined): void;
-};
-
-const openPopup = (url: string | undefined) => {
-  popupWindow = window.open(
-    url,
-    MESSAGE_TYPE.JIARY_SIGNIN_MESSAGE,
-    'toolbar=no, width=560, height=700, top=100, left=100'
-  );
-};
+import { useEffect, useRef, useState } from 'react';
 
 export const useAuth = () => {
-  const getAccessTokenMutation = useGetAccessToken();
-  const getUserInfoMutation = useGetUserInfo();
-  const logoutMutation = useLogout();
+  const [code, setCode] = useState('');
+  const popWindowRef = useRef<Window | null>(null);
+  const { data: accessToken } = useGetAccessToken(code);
+  const { data: userInfo } = useGetUserInfo(accessToken?.token || '');
+
   const dispatch = useDispatch();
   const router = useRouter();
-  const queryClient = useQueryClient();
 
-  const messageCallback = async (event: MessageEvent) => {
+  const messageCallback = (event: MessageEvent, popupWindow: Window | null) => {
     if (event.origin !== JIARY_DOMAIN) {
       // eslint-disable-next-line no-console
       console.error('Cross-Origin Error');
       return;
     }
+    popWindowRef.current = popupWindow;
 
     const receiveData = event.data;
     if (receiveData.type !== MESSAGE_TYPE.JIARY_SIGNIN_MESSAGE) {
       return;
     }
+    const code = new URL(receiveData.params).searchParams.get('code');
+    setCode(code || '');
+  };
 
-    const url = new URL(receiveData.params);
-    const searchParams = url.searchParams;
-    const { token: accessToken } = await getAccessTokenMutation.mutateAsync(
-      searchParams.get('code') || ''
-    );
-    if (!accessToken) throw new Error('엑세스 토큰이 없습니다.');
-    const userInfo = await getUserInfoMutation.mutateAsync(accessToken);
-
-    localStorage.setItem('accessToken', accessToken);
+  useEffect(() => {
+    if (!accessToken?.token || !userInfo?.id) return;
+    localStorage.setItem('accessToken', accessToken.token);
     localStorage.setItem('user', JSON.stringify(userInfo));
     dispatch(setUser(userInfo));
     dispatch(setAccessToken(accessToken));
 
-    popupWindow?.close();
-    window.removeEventListener('message', messageCallback, false);
+    popWindowRef.current?.close();
+    window.removeEventListener(
+      'message',
+      e => messageCallback(e, popWindowRef.current),
+      false
+    );
     router.push('/diary');
-  };
+  }, [accessToken, userInfo, dispatch, router]);
 
-  const openLoginPopup: OpenLoginPopup = (url: string | undefined) => {
-    if (popupWindow === null || popupWindow.closed) {
-      openPopup(url);
-    } else if (window.location.href !== `${JIARY_DOMAIN}/auth`) {
-      openPopup(url);
-      popupWindow.focus();
-    } else {
-      popupWindow.focus();
-      return;
-    }
-
-    window.addEventListener('message', messageCallback, false);
-  };
-
-  const logout = () => {
-    const confirm = window.confirm('로그아웃 하시겠습니까?');
-    if (!confirm) return;
-
-    logoutMutation.mutate();
-    localStorage.removeItem('accessToken');
-    localStorage.removeItem('user');
-    dispatch(removeUser());
-    dispatch(removeAccessToken());
-    queryClient.clear();
-    router.push('/');
-  };
-
-  return { openLoginPopup, logout };
+  return { messageCallback };
 };

--- a/src/features/auth/hooks/useLoginPopup.ts
+++ b/src/features/auth/hooks/useLoginPopup.ts
@@ -1,0 +1,36 @@
+import { MESSAGE_TYPE } from '@/constants/auth.ts';
+import { JIARY_DOMAIN } from '@/constants/domain.ts';
+import { useAuth } from '@/features/auth/hooks/useAuth.ts';
+
+let popupWindow: Window | null = null;
+
+const openPopup = (url: string | undefined) => {
+  popupWindow = window.open(
+    url,
+    MESSAGE_TYPE.JIARY_SIGNIN_MESSAGE,
+    'toolbar=no, width=560, height=700, top=100, left=100'
+  );
+};
+
+export const useLoginPopup = () => {
+  const { messageCallback } = useAuth();
+  const openLoginPopup = (url: string | undefined) => {
+    if (popupWindow === null || popupWindow.closed) {
+      openPopup(url);
+    } else if (window.location.href !== `${JIARY_DOMAIN}/auth`) {
+      openPopup(url);
+      popupWindow.focus();
+    } else {
+      popupWindow.focus();
+      return;
+    }
+
+    window.addEventListener(
+      'message',
+      e => messageCallback(e, popupWindow),
+      false
+    );
+  };
+
+  return { openLoginPopup };
+};

--- a/src/features/auth/hooks/useLogout.ts
+++ b/src/features/auth/hooks/useLogout.ts
@@ -1,0 +1,27 @@
+import { useDispatch } from 'react-redux';
+import { removeAccessToken, removeUser } from '@/store/slices/authSlice.ts';
+import { useRouter } from 'next/router';
+import { useQueryClient } from '@tanstack/react-query';
+import useLogoutMutation from '@/features/auth/apis/mutations/useLogoutMutation.ts';
+
+export const useLogout = () => {
+  const logoutMutation = useLogoutMutation();
+  const dispatch = useDispatch();
+  const router = useRouter();
+  const queryClient = useQueryClient();
+
+  const logout = () => {
+    const confirm = window.confirm('로그아웃 하시겠습니까?');
+    if (!confirm) return;
+
+    logoutMutation.mutate();
+    localStorage.removeItem('accessToken');
+    localStorage.removeItem('user');
+    dispatch(removeUser());
+    dispatch(removeAccessToken());
+    queryClient.clear();
+    router.push('/');
+  };
+
+  return { logout };
+};

--- a/src/features/auth/pages/root/AuthPage.tsx
+++ b/src/features/auth/pages/root/AuthPage.tsx
@@ -3,13 +3,8 @@ import LoginSection from '@/features/auth/components/LoginSection/LoginSection.t
 import loginBackground from '@/static/auth/open-peeps.png';
 import * as style from '@/features/auth/pages/root/AuthPage.css.ts';
 import Head from 'next/head';
-import { OpenLoginPopup } from '@/features/auth/hooks/useAuth.ts';
 
-type Props = {
-  openLoginPopup: OpenLoginPopup;
-};
-
-export default function AuthPage({ openLoginPopup }: Props) {
+export default function AuthPage() {
   return (
     <div className={style.container}>
       <Head>
@@ -23,7 +18,7 @@ export default function AuthPage({ openLoginPopup }: Props) {
         placeholder="blur"
       />
       <div className={style.backgroundAfter}></div>
-      <LoginSection openLoginPopup={openLoginPopup} />
+      <LoginSection />
     </div>
   );
 }

--- a/src/features/common/components/profile/UserProfile.tsx
+++ b/src/features/common/components/profile/UserProfile.tsx
@@ -3,11 +3,11 @@ import { RootState } from '../../../../store/store.ts';
 import * as style from '@/features/common/components/profile/UserProfile.css.ts';
 import Image from 'next/image';
 import Dropdown from '@/features/common/components/dropdown/Dropdown.tsx';
-import { useAuth } from '@/features/auth/hooks/useAuth.ts';
+import { useLogout } from '@/features/auth/hooks/useLogout.ts';
 
 export default function UserProfile() {
   const user = useSelector((state: RootState) => state.auth.user);
-  const { logout } = useAuth();
+  const { logout } = useLogout();
 
   return (
     <Dropdown>

--- a/src/pages/auth/index.tsx
+++ b/src/pages/auth/index.tsx
@@ -1,8 +1,1 @@
-import AuthPage from '@/features/auth/pages/root/AuthPage.tsx';
-import { useAuth } from '@/features/auth/hooks/useAuth.ts';
-
-export default function Index() {
-  const { openLoginPopup } = useAuth();
-
-  return <AuthPage openLoginPopup={openLoginPopup} />;
-}
+export { default } from '@/features/auth/pages/root/AuthPage.tsx';


### PR DESCRIPTION
- useQuery를 사용해야 할 곳에, mutation을 사용한 것 걷어냄. useQuery에 enabled 적용
- 로그인 시 사용하는 useAuth 훅을 3개로 분리
- auth page를 re-export 형태로 수정