### PR TITLE
fix: github actions trigger 1개로 수정

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,10 +1,8 @@
-name: Deploy-Preview
+name: Preview
 env:
   VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
   VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
 on:
-  push:
-    branches-ignore: main
   pull_request_target:
     types: [labeled]
 jobs:


### PR DESCRIPTION
## 주제

- github actions trigger 1개로 수정

## 작업 내용

- 기존 push와 pull_request_target으로 2개였던 trigger 요소를 pull_request_target만 남기도록 수정

