### PR TITLE
fix: backend에서 로그인 성공 후 cookie에 domain, samesite 포함 설정

### DIFF
--- a/src/backend/auth/httpMethods/POST.ts
+++ b/src/backend/auth/httpMethods/POST.ts
@@ -23,8 +23,8 @@ export async function POST(
 
       setCookie(res, 'Authorization', tokens.access_token, {
         httpOnly: true,
-        // sameSite: process.env.NEXT_PUBLIC_MODE !== 'development',
-        // domain: process.env.NEXT_PUBLIC_DOMAIN_URI,
+        sameSite: true,
+        domain: process.env.NEXT_PUBLIC_DOMAIN,
         path: '/',
         maxAge: 60 * 60 * 24 * 20, // 20일
       });


### PR DESCRIPTION
## 주제

- 로그인 후, cookie가 세팅될 때 samesite=strict, domain이 붙도록 설정

## 작업 내용

- backend auth 이후, setCookie header에 samesite, domain을 붙여 보안성 높임.
