### PR TITLE
chore: use local lint-staged

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-npx lint-staged
+npm run lint-staged

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "start": "next start",
     "lint": "next lint --fix",
     "format": "prettier --write --cache .",
+    "lint-staged": "lint-staged",
     "prepare": "husky install"
   },
   "dependencies": {


### PR DESCRIPTION
## 주제

- lint-staged가 local 패키지를 사용하도록 수정

## 작업 내용

- lint-staged가 devDependencies에 있는데, husky에서 npx 명령어로 실행되고 있기 때문에 `npm run lint-staged` 명령어로 다운 받은 패키지로 실행하도록 수정

