### PR TITLE
refactor: header의 ul 태그 하위로 div 태그 제거

### DIFF
--- a/src/features/common/components/header/PageHeader.css.ts
+++ b/src/features/common/components/header/PageHeader.css.ts
@@ -12,11 +12,11 @@ export const header = style({
   background: '#1a1b1e',
 });
 
-export const nav = style({
+export const navContainer = style({
   height: '100%',
 });
 
-export const ul = style({
+export const nav = style({
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'space-between',
@@ -25,7 +25,7 @@ export const ul = style({
   margin: '0 auto',
 });
 
-export const sideDiv = style({
+export const ul = style({
   display: 'flex',
   alignItems: 'center',
   height: 35,

--- a/src/features/common/components/header/PageHeader.tsx
+++ b/src/features/common/components/header/PageHeader.tsx
@@ -13,9 +13,9 @@ export default function PageHeader() {
 
   return (
     <header className={style.header}>
-      <nav className={style.nav}>
-        <ul className={style.ul}>
-          <div className={style.sideDiv}>
+      <div className={style.navContainer}>
+        <nav className={style.nav}>
+          <ul className={style.ul}>
             <li className="jiary-logo">
               <Link href="/" className={style.imageLogoWrapper}>
                 <Image
@@ -31,9 +31,9 @@ export default function PageHeader() {
                 Diary
               </Link>
             </li>
-          </div>
+          </ul>
 
-          <div className={style.sideDiv}>
+          <ul className={style.ul}>
             <li className={style.li}>
               <Link
                 href="https://github.com/pozafly/jiary"
@@ -60,9 +60,9 @@ export default function PageHeader() {
                 </Link>
               </li>
             )}
-          </div>
-        </ul>
-      </nav>
+          </ul>
+        </nav>
+      </div>
     </header>
   );
 }


### PR DESCRIPTION
## 주제

- light house의 accessibility 기준 적용

## 작업 내용

- PageHeader 컴포넌트에서 ul 태그 하위로 li 태그 외 div 태그가 존재하여 제거
